### PR TITLE
Update get_snapshots_202x.py

### DIFF
--- a/CVP_API/Snapshot_Utils/getSnapshots_Resource_API/get_snapshots_202x.py
+++ b/CVP_API/Snapshot_Utils/getSnapshots_Resource_API/get_snapshots_202x.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests","cloudvision","fuzzywuzzy","python-Levenshtein","xlrd"]
+# [tool.uv]
+# exclude-newer = "2024-10-01T00:00:00Z"
+# ///
+
 #!/usr/bin/env python3
 #
 # Copyright (c) 2021, Arista Networks, Inc.


### PR DESCRIPTION
As requirements.txt file don't have dependencies versions pinned there is a chance we install versions which cannot be used with the script. Someone used python3.9 and was able to install cloudvision 1.0.0 module so the script was failing. Adding the uv inline script metadata to make sure the last python version is used and newest version of the libraries are installed that satisfy the dependency graph and do not violate the timestamp given.